### PR TITLE
Bumped deps, improved docs, removed abbreviations from quantizer stru…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,14 @@ exclude = ["*.jpg", "assets/*", "*.png", "assets/bench.jpg", "assets/bench.png",
 rust-version = "1.82.0"
 
 [dependencies]
-num-traits = "0.2.19"
-moxcms = "0.3.0"
-quick-xml = { version =  "0.37.2", features = ["serde", "serde-types", "serialize"] }
-serde = { version = "1.0.218", features = ["derive"] }
+moxcms = "0.3"
+num-traits = "0.2"
+quick-xml = { version = "0.37", features = ["serde", "serde-types", "serialize"], optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+
+[features]
+default = []
+uhdr = ["dep:serde", "dep:quick-xml"]
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/README.md
+++ b/README.md
@@ -1,47 +1,52 @@
-# HDR tone mapping library in Rust
+# `gainforge` – HDR tone mapping in Rust
 
-Library helps perform tone mapping from HDR to SDR
+<!-- cargo-rdme start -->
 
-## Example
+Tone mapping – from HDR to SDR.
+
+### Example
 
 ```rust
-    let img = image::ImageReader::open("./assets/hdr.avif")
-        .unwrap()
-        .decode()
-        .unwrap();
-    let rgb = img.to_rgb8();
+let img = image::ImageReader::open("./assets/hdr.avif")?
+    .decode()?;
+let rgb = img.to_rgb8();
 
-    let tone_mapper = create_tone_mapper_rgb(
-        HdrTransferFunction::Pq,
-        GamutColorSpace::Bt2020,
-        TransferFunction::Srgb,
-        GamutColorSpace::Srgb,
-        ToneMappingMethod::Rec2408(GainHdrMetadata::new(2000f32, 250f32)),
-        GamutClipping::Clip,
-    );
-    let dims = rgb.dimensions();
-    let mut dst = vec![0u8; rgb.len()];
-    for (src, dst) in rgb
-        .chunks_exact(rgb.dimensions().0 as usize * 3)
-        .zip(dst.chunks_exact_mut(rgb.dimensions().0 as usize * 3))
-    {
-        tone_mapper.tonemap_lane(src, dst).unwrap();
-    }
-    
-    image::save_buffer(
-        "processed.jpg",
-        &dst,
-        dims.0,
-        dims.1,
-        image::ExtendedColorType::Rgb8,
-    )
-    .unwrap();
+let tone_mapper = create_tone_mapper_rgb(
+    HdrTransferFunction::PerceptualQuantizer,
+    GamutColorSpace::Bt2020,
+    TransferFunction::Srgb,
+    GamutColorSpace::Srgb,
+    ToneMappingMethod::Rec2408(GainHdrMetadata{
+        content_max_brightness: 2000f32,
+        display_max_brightness: 250f32,
+    }),
+    GamutClipping::Clip,
+);
+
+let dims = rgb.dimensions();
+let mut dst = vec![0u8; rgb.len()];
+for (src, dst) in rgb
+    .chunks_exact(rgb.dimensions().0 as usize * 3)
+    .zip(dst.chunks_exact_mut(rgb.dimensions().0 as usize * 3))
+{
+    tone_mapper.tonemap_lane(src, dst)?;
+}
+
+image::save_buffer(
+    "processed.jpg",
+    &dst,
+    dims.0,
+    dims.1,
+    image::ExtendedColorType::Rgb8,
+)?;
 ```
 
-# How to handle UHDR
+### UHDR Support
 
-Some patches on zune-image still in processing, resolving package
-from zune-image might be required
+This requires the `uhdr` feature to be enabled.
+
+Some patches on `zune-image` are still being processed. Manually updating a
+dependency of `zune-image` might be required.
 
 ```rust
 pub struct GainMapAssociationGroup {
@@ -63,18 +68,19 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
     decoder
         .decode_headers()
         .expect("Failed to decode JPEG headers");
-    // Decode first image (Primary)
+
+    // Decode first image (primary).
     let primary_image = decoder.decode().expect("Failed to decode primary image");
     let primary_metadata = decoder.info().expect("No metadata found");
 
-    // Multi picture format information, if you want to do something with it
+    // Multi picture format information, if you want to do something with it.
     let parsed_mpf =
-        MpfInfo::from_bytes(&decoder.info().unwrap().multi_picture_information.unwrap()).unwrap();
+        MpfInfo::from_bytes(&decoder.info()?.multi_picture_information.unwrap()).unwrap();
 
     let cv = Vec::new();
     let primary_xmp = decoder.xmp().unwrap_or(&cv);
 
-    // UHDR directory info if needed
+    // UHDR directory info if needed.
     let uhdr_directory = UhdrDirectoryContainer::from_xml(primary_xmp);
 
     let image_icc = decoder
@@ -82,20 +88,20 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
         .and_then(|icc| ColorProfile::new_from_slice(&icc).ok());
 
     // Read the second image from JPEG file
-
-    // This might be done using MPF
-    // or by last read stream position.
-
+    //
+    // This might be done using MPF or by last read stream position.
     let file = File::open(file_path).expect("Failed to open file");
     let mut reader2 = BufReader::new(file);
-    // Zune have bug where some streams consumed in full, some or not, it might
-    // be needed to adjust stream position using MPF or any other approach
+
+    // Zune has a bug where some streams consumed in full, some or not, it
+    // may be neccessary to adjust stream position using MPF or any other
+    // approach.
     // At the moment some images works when +2 is added, some images are not.
-    // *Was fixed in the latest commits of zune-jpeg.*
-    let stream_pos = reader.stream_position().unwrap();
-    reader2.seek(SeekFrom::Start(stream_pos)).unwrap();
+    // *This was fixed in the latest commits of `zune-jpeg`.*
+    let stream_pos = reader.stream_position()?;
+    reader2.seek(SeekFrom::Start(stream_pos))?;
     let mut dst_vec = Vec::new();
-    reader2.read_to_end(&mut dst_vec).unwrap();
+    reader2.read_to_end(&mut dst_vec)?;
 
     let mut decoder = JpegDecoder::new(Cursor::new(dst_vec.to_vec()));
 
@@ -103,14 +109,13 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
         .decode_headers()
         .expect("Failed to decode JPEG headers");
 
-    // Gain map might be stored either in XMP and APP2 iso chunk
+    // Gain map might be stored either in XMP and APP2 ISO chunk.
     let xmp_data = decoder
         .xmp()
         .map(|x| x.to_vec())
-        .or(Some(Vec::new()))
-        .unwrap();
+        .or(Some(Vec::new()))?;
 
-    // New zune-jpeg is required
+    // Latest `zune-jpeg` is required.
     let gainmap_info = if decoder.info().unwrap().gain_map_info.len() > 0 {
         decoder.info().unwrap().gain_map_info[0].data.to_vec()
     } else {
@@ -124,9 +129,9 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
         .icc_profile()
         .and_then(|icc| ColorProfile::new_from_slice(&icc).ok());
 
-    let mut gain_map_image = decoder.decode().unwrap();
+    let mut gain_map_image = decoder.decode()?;
 
-    let gain_map_image_info = decoder.info().unwrap();
+    let gain_map_image_info = decoder.info()?;
 
     // Gain map might have 3 components, or 1.
     // Might be in full size or 1/4.
@@ -142,8 +147,7 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
             &gain_map_image,
             gain_map_image_info.width as usize,
             gain_map_image_info.height as usize,
-        )
-        .unwrap();
+        )?;
         let mut scaler = pic_scale::Scaler::new(pic_scale::ResamplingFunction::Lanczos3);
         scaler.set_workload_strategy(pic_scale::WorkloadStrategy::PreferQuality);
         let mut dst_image = pic_scale::ImageStoreMut::<u8, 3>::alloc(
@@ -151,7 +155,7 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
             primary_metadata.height as usize,
         );
         use pic_scale::Scaling;
-        scaler.resize_rgb(&source_image, &mut dst_image).unwrap();
+        scaler.resize_rgb(&source_image, &mut dst_image)?;
         gain_map_image = dst_image.buffer.borrow().to_vec();
     }
 
@@ -166,12 +170,12 @@ fn extract_images(file_path: &str) -> GainMapAssociationGroup {
     }
 }
 
-// Load required associated images
+// Load required associated images.
 let associated = extract_images("./assets/uhdr_01.jpg");
 
 let gainmap = associated.metadata.to_gain_map();
 
-// Get maximum display boost from screen information
+// Get maximum display boost from screen information.
 let display_boost = 1.3f32;
 let gainmap_weight = make_gainmap_weight(gainmap, display_boost);
 
@@ -181,10 +185,10 @@ let gain_image =
 GainImage::<u8, 3>::borrow(&associated.gain_map, associated.width, associated.height);
 let mut dst_image = GainImageMut::<u8, 3>::alloc(associated.width, associated.height);
 
-// Screen colorspace
+// Screen colorspace.
 let dest_profile = ColorProfile::new_srgb();
 
-// And finally apply gain map
+// And finally apply gain map.
 apply_gain_map_rgb(
     &source_image,
     &associated.icc_profile,
@@ -194,9 +198,16 @@ apply_gain_map_rgb(
     &associated.gain_map_icc_profile,
     gainmap,
     gainmap_weight,
-)
-.unwrap();
+)?;
 ```
+
+### Features
+- `uhdr` -- Enable Ultra HDR/[ISO 21496-1 Gain Map](https://www.iso.org/standard/86775.html) support.
+  > ⚠️ This will pull in `serde` and `quick-xml` dependencies.
+
+<!-- cargo-rdme end -->
+
+## License
 
 This project is licensed under either of
 

--- a/src/gamma.rs
+++ b/src/gamma.rs
@@ -338,24 +338,24 @@ impl TransferFunction {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum HdrTransferFunction {
-    Pq,
-    Hlg,
+    PerceptualQuantizer,
+    HybridLogGamma,
 }
 
 impl HdrTransferFunction {
     #[inline(always)]
     pub fn linearize(&self, v: f32) -> f32 {
         match self {
-            HdrTransferFunction::Pq => pq_to_linear(v),
-            HdrTransferFunction::Hlg => hlg_to_linear(v),
+            HdrTransferFunction::PerceptualQuantizer => pq_to_linear(v),
+            HdrTransferFunction::HybridLogGamma => hlg_to_linear(v),
         }
     }
 
     #[inline(always)]
     pub fn gamma(&self, v: f32) -> f32 {
         match self {
-            HdrTransferFunction::Pq => pq_from_linear(v),
-            HdrTransferFunction::Hlg => hlg_from_linear(v),
+            HdrTransferFunction::PerceptualQuantizer => pq_from_linear(v),
+            HdrTransferFunction::HybridLogGamma => hlg_from_linear(v),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,18 +26,223 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+//! Tone mapping – from HDR to SDR.
+//!
+//! ## Example
+//!
+//! ```rust
+//! let img = image::ImageReader::open("./assets/hdr.avif")?
+//!     .decode()?;
+//! let rgb = img.to_rgb8();
+//!
+//! let tone_mapper = create_tone_mapper_rgb(
+//!     HdrTransferFunction::PerceptualQuantizer,
+//!     GamutColorSpace::Bt2020,
+//!     TransferFunction::Srgb,
+//!     GamutColorSpace::Srgb,
+//!     ToneMappingMethod::Rec2408(GainHdrMetadata{
+//!         content_max_brightness: 2000f32,
+//!         display_max_brightness: 250f32,
+//!     }),
+//!     GamutClipping::Clip,
+//! );
+//!
+//! let dims = rgb.dimensions();
+//! let mut dst = vec![0u8; rgb.len()];
+//! for (src, dst) in rgb
+//!     .chunks_exact(rgb.dimensions().0 as usize * 3)
+//!     .zip(dst.chunks_exact_mut(rgb.dimensions().0 as usize * 3))
+//! {
+//!     tone_mapper.tonemap_lane(src, dst)?;
+//! }
+//!
+//! image::save_buffer(
+//!     "processed.jpg",
+//!     &dst,
+//!     dims.0,
+//!     dims.1,
+//!     image::ExtendedColorType::Rgb8,
+//! )?;
+//! ```
+//!
+//! ## UHDR Support
+//!
+//! This requires the `uhdr` feature to be enabled.
+//!
+//! Some patches on `zune-image` are still being processed. Manually updating a
+//! dependency of `zune-image` might be required.
+//!
+//! ```rust
+//! pub struct GainMapAssociationGroup {
+//!     pub image: Vec<u8>,
+//!     pub gain_map: Vec<u8>,
+//!     pub width: usize,
+//!     pub height: usize,
+//!     pub icc_profile: Option<ColorProfile>,
+//!     pub gain_map_icc_profile: Option<ColorProfile>,
+//!     pub metadata: IsoGainMap,
+//! }
+//!
+//! fn extract_images(file_path: &str) -> GainMapAssociationGroup {
+//!     let file = File::open(file_path).expect("Failed to open file");
+//!
+//!     let mut reader = BufReader::new(file);
+//!
+//!     let mut decoder = JpegDecoder::new(&mut reader);
+//!     decoder
+//!         .decode_headers()
+//!         .expect("Failed to decode JPEG headers");
+//!
+//!     // Decode first image (primary).
+//!     let primary_image = decoder.decode().expect("Failed to decode primary image");
+//!     let primary_metadata = decoder.info().expect("No metadata found");
+//!
+//!     // Multi picture format information, if you want to do something with it.
+//!     let parsed_mpf =
+//!         MpfInfo::from_bytes(&decoder.info()?.multi_picture_information.unwrap()).unwrap();
+//!
+//!     let cv = Vec::new();
+//!     let primary_xmp = decoder.xmp().unwrap_or(&cv);
+//!
+//!     // UHDR directory info if needed.
+//!     let uhdr_directory = UhdrDirectoryContainer::from_xml(primary_xmp);
+//!
+//!     let image_icc = decoder
+//!         .icc_profile()
+//!         .and_then(|icc| ColorProfile::new_from_slice(&icc).ok());
+//!
+//!     // Read the second image from JPEG file
+//!     //
+//!     // This might be done using MPF or by last read stream position.
+//!     let file = File::open(file_path).expect("Failed to open file");
+//!     let mut reader2 = BufReader::new(file);
+//!
+//!     // Zune has a bug where some streams consumed in full, some or not, it
+//!     // may be neccessary to adjust stream position using MPF or any other
+//!     // approach.
+//!     // At the moment some images works when +2 is added, some images are not.
+//!     // *This was fixed in the latest commits of `zune-jpeg`.*
+//!     let stream_pos = reader.stream_position()?;
+//!     reader2.seek(SeekFrom::Start(stream_pos))?;
+//!     let mut dst_vec = Vec::new();
+//!     reader2.read_to_end(&mut dst_vec)?;
+//!
+//!     let mut decoder = JpegDecoder::new(Cursor::new(dst_vec.to_vec()));
+//!
+//!     decoder
+//!         .decode_headers()
+//!         .expect("Failed to decode JPEG headers");
+//!
+//!     // Gain map might be stored either in XMP and APP2 ISO chunk.
+//!     let xmp_data = decoder
+//!         .xmp()
+//!         .map(|x| x.to_vec())
+//!         .or(Some(Vec::new()))?;
+//!
+//!     // Latest `zune-jpeg` is required.
+//!     let gainmap_info = if decoder.info().unwrap().gain_map_info.len() > 0 {
+//!         decoder.info().unwrap().gain_map_info[0].data.to_vec()
+//!     } else {
+//!         Vec::new()
+//!     };
+//!     let gain_map = IsoGainMap::from_metadata(&gainmap_info)
+//!         .or_else(|_| IsoGainMap::from_xml_data(&xmp_data))
+//!         .unwrap();
+//!
+//!     let gain_map_icc = decoder
+//!         .icc_profile()
+//!         .and_then(|icc| ColorProfile::new_from_slice(&icc).ok());
+//!
+//!     let mut gain_map_image = decoder.decode()?;
+//!
+//!     let gain_map_image_info = decoder.info()?;
+//!
+//!     // Gain map might have 3 components, or 1.
+//!     // Might be in full size or 1/4.
+//!     // this implementation always returns full image in 3 components.
+//!     if gain_map_image_info.components == 1 {
+//!         gain_map_image = gain_map_image.iter().flat_map(|&x| [x, x, x]).collect();
+//!     }
+//!
+//!     if gain_map_image_info.width != primary_metadata.width
+//!         || gain_map_image_info.height != primary_metadata.height
+//!     {
+//!         let source_image = pic_scale::ImageStore::<u8, 3>::borrow(
+//!             &gain_map_image,
+//!             gain_map_image_info.width as usize,
+//!             gain_map_image_info.height as usize,
+//!         )?;
+//!         let mut scaler = pic_scale::Scaler::new(pic_scale::ResamplingFunction::Lanczos3);
+//!         scaler.set_workload_strategy(pic_scale::WorkloadStrategy::PreferQuality);
+//!         let mut dst_image = pic_scale::ImageStoreMut::<u8, 3>::alloc(
+//!             primary_metadata.width as usize,
+//!             primary_metadata.height as usize,
+//!         );
+//!         use pic_scale::Scaling;
+//!         scaler.resize_rgb(&source_image, &mut dst_image)?;
+//!         gain_map_image = dst_image.buffer.borrow().to_vec();
+//!     }
+//!
+//!     GainMapAssociationGroup {
+//!         image: primary_image,
+//!         gain_map: gain_map_image,
+//!         width: primary_metadata.width as usize,
+//!         height: primary_metadata.height as usize,
+//!         icc_profile: image_icc,
+//!         gain_map_icc_profile: gain_map_icc,
+//!         metadata: gain_map,
+//!     }
+//! }
+//!
+//! // Load required associated images.
+//! let associated = extract_images("./assets/uhdr_01.jpg");
+//!
+//! let gainmap = associated.metadata.to_gain_map();
+//!
+//! // Get maximum display boost from screen information.
+//! let display_boost = 1.3f32;
+//! let gainmap_weight = make_gainmap_weight(gainmap, display_boost);
+//!
+//! let source_image =
+//! GainImage::<u8, 3>::borrow(&associated.image, associated.width, associated.height);
+//! let gain_image =
+//! GainImage::<u8, 3>::borrow(&associated.gain_map, associated.width, associated.height);
+//! let mut dst_image = GainImageMut::<u8, 3>::alloc(associated.width, associated.height);
+//!
+//! // Screen colorspace.
+//! let dest_profile = ColorProfile::new_srgb();
+//!
+//! // And finally apply gain map.
+//! apply_gain_map_rgb(
+//!     &source_image,
+//!     &associated.icc_profile,
+//!     &mut dst_image,
+//!     &dest_profile,
+//!     &gain_image,
+//!     &associated.gain_map_icc_profile,
+//!     gainmap,
+//!     gainmap_weight,
+//! )?;
+//! ```
+//!
+//! ## Features
+//! - `uhdr` -- Enable Ultra HDR/[ISO 21496-1 Gain Map](https://www.iso.org/standard/86775.html) support.
+//!   > ⚠️ This will pull in `serde` and `quick-xml` dependencies.
 #![allow(clippy::manual_clamp, clippy::excessive_precision)]
+#[cfg(feature = "uhdr")]
 mod apply_gain_map;
 mod cms;
 mod err;
 mod gain_image;
 mod gamma;
+#[cfg(feature = "uhdr")]
 mod iso_gain_map;
 mod mappers;
 mod mlaf;
 mod spline;
 mod tonemapper;
 
+#[cfg(feature = "uhdr")]
 pub use apply_gain_map::{
     apply_gain_map_rgb, apply_gain_map_rgb10, apply_gain_map_rgb12, apply_gain_map_rgb16,
     apply_gain_map_rgba, apply_gain_map_rgba10, apply_gain_map_rgba12, apply_gain_map_rgba16,
@@ -46,6 +251,7 @@ pub use cms::GamutColorSpace;
 pub use err::ForgeError;
 pub use gain_image::{BufferStore, GainImage, GainImageMut};
 pub use gamma::{HdrTransferFunction, TransferFunction};
+#[cfg(feature = "uhdr")]
 pub use iso_gain_map::{
     make_gainmap_weight, IsoGainMap, MpfDataType, MpfEndianness, MpfEntry, MpfImageType, MpfInfo,
     MpfNumberOfImages, MpfTag, UhdrDirectory, UhdrDirectoryContainer, UhdrDirectoryRdf,

--- a/src/mappers.rs
+++ b/src/mappers.rs
@@ -31,19 +31,37 @@ use crate::spline::FilmicSplineParameters;
 use crate::GainHdrMetadata;
 use std::ops::{Add, Div, Mul, Sub};
 
-/// Defines tone mapping method
+/// Defines a tone mapping method.
 ///
 /// All tone mappers are local unless other is stated.
+///
+/// See [this blog post](https://64.github.io/tonemapping/) for more details on
+/// many of the supported tone mapping methods.
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 pub enum ToneMappingMethod {
+    /// To do.
     Rec2408(GainHdrMetadata),
+    /// The ['Uncharted 2' filmic](https://www.gdcvault.com/play/1012351/Uncharted-2-HDR)
+    /// tone mapping method.
     Filmic,
+    /// The [Academy Color Encoding System](https://github.com/ampas/aces-core)
+    /// filmic tone mapping method.
     Aces,
+    /// Erik Reinhard's tone mapper from the paper "Photographic tone
+    /// reproduction for digital images".
     Reinhard,
+    /// Same as `Reinhard` but but scales the output to the full dynamic
+    /// range of the image.
     ExtendedReinhard,
+    /// A variation of `Reinhard` that uses mixes color-based- with
+    /// luminance-based tone mapping.
     ReinhardJodie,
+    /// Simply clamp the output to the available dynamic range.
     Clamp,
+    /// To do.
     Alu,
+    /// This is a parameterized curve based on the Blender Filmic tone mapping
+    /// method similar to the module found in Ansel/Darktable.
     FilmicSpline(FilmicSplineParameters),
 }
 

--- a/src/tonemapper.rs
+++ b/src/tonemapper.rs
@@ -375,18 +375,7 @@ fn make_mapper<const CN: usize>(
 
 macro_rules! define8 {
     ($method: ident, $cn: expr, $name: expr) => {
-        #[doc = concat!("Creates ", $name," tone mapper
-
-# Arguments
-
-* `content_hdr_metadata`: see [GainHDRMetadata]
-* `hdr_transfer_function`: see [HdrTransferFunction]
-* `input_color_space`: see [GamutColorSpace]
-* `display_transfer_function`: see [TransferFunction]
-* `output_color_space`: see [GamutColorSpace]
-* `method`: see [ToneMappingMethod]
-
-returns: Box<dyn ToneMapper<u8> + Send+Sync, Global>")]
+        #[doc = concat!("Creates an ", $name," tone mapper.")]
         pub fn $method(
             hdr_transfer_function: HdrTransferFunction,
             input_color_space: GamutColorSpace,
@@ -412,18 +401,7 @@ define8!(create_tone_mapper_rgba, 4, "RGBA8");
 
 macro_rules! define16 {
     ($method: ident, $cn: expr, $bp: expr, $name: expr) => {
-        #[doc = concat!("Creates ", $name," tone mapper
-
-# Arguments
-
-* `content_hdr_metadata`: see [GainHDRMetadata]
-* `hdr_transfer_function`: see [HdrTransferFunction]
-* `input_color_space`: see [GamutColorSpace]
-* `display_transfer_function`: see [TransferFunction]
-* `output_color_space`: see [GamutColorSpace]
-* `method`: see [ToneMappingMethod]
-
-returns: Box<dyn ToneMapper<u8> + Send+Sync, Global>")]
+        #[doc = concat!("Creates an ", $name," tone mapper.")]
         pub fn $method(
             hdr_transfer_function: HdrTransferFunction,
             input_color_space: GamutColorSpace,


### PR DESCRIPTION
* Bumped deps.
* Improved docs.
* Removed abbreviations from `HdrTransferFunction`.
* Moved most of `README.md` to `lib.rs` (so it is available in the crate docs).
* The latter can be updated via [`cargo-rdme`](https://crates.io/crates/cargo-rdme). I.e. only change docs in `lib.rs` then run:
   ```
   cargo rdme
   ```
   in the project root.